### PR TITLE
fix: Remove extraneous "KLM" characters from beginning of NIE check

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -41,7 +41,7 @@ class Validator
     public function isValidNie(?string $value): bool
     {
         if ($value) {
-            $regEx = '/^[KLMXYZ][0-9]{7}[A-Z]$/i';
+            $regEx = '/^[XYZ][0-9]{7}[A-Z]$/i';
             $letters = 'TRWAGMYFPDXBNJZSQVHLCKE';
 
             $value = strtoupper($value);


### PR DESCRIPTION
If such characters were present in the NIE to be checked a TypeError would be thrown:

TypeError: Unsupported operand types: string % int

Tried to find any evidence of these charatcters actually being allowed for Spanish NIE but no evidence of such a thing was found. If this were an error and they are in fact supported then proper handling of those inputs is advised.

Also, haven't found any tests for this, adding to the assumption this isn't intentional.